### PR TITLE
Code-first <Chunk src="...." /> for images

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "dompurify": "^2.0.11",
     "lodash-es": "^4.17.15",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1",
-    "swr": "^0.2.2"
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "^9.35.1",

--- a/src/Chunk.jsx
+++ b/src/Chunk.jsx
@@ -3,8 +3,10 @@
 import React from "react";
 import { useChunk } from "./useChunk";
 
-export function Chunk({ children, identifier, ...props }) {
-  const { Component } = useChunk(children, { identifier });
+export function Chunk({ children, identifier, src, ...props }) {
+  const type = src ? "image" : undefined;
+  const defaultContent = src || children;
+  const { Component } = useChunk(defaultContent, { identifier, type });
 
   return <Component {...props} />;
 }

--- a/src/ChunkCollection.jsx
+++ b/src/ChunkCollection.jsx
@@ -1,17 +1,18 @@
 // @ts-check
-import React from "react";
-import useSWR from "swr";
+import React, { useEffect, useState } from "react";
 
 import { api } from "./api";
 import { ChunkCollectionContext } from "./ChunkCollectionContext";
 
 export function ChunkCollection({ children, className, identifier }) {
-  const {
-    data: chunks = [],
-    error,
-  } = useSWR(`chunks?collection_identifier=${identifier}`, (url) =>
-    api.get(url).then((res) => res.data.chunks)
-  );
+  const [[error, chunks], setResponse] = useState([undefined, []]);
+
+  useEffect(() => {
+    api
+      .get(`chunks?collection_identifier=${identifier}`)
+      .then((res) => setResponse([null, res.data.chunks]))
+      .catch((error) => setResponse([error, []]));
+  }, [identifier]);
 
   if (error) {
     console.log(
@@ -22,7 +23,7 @@ export function ChunkCollection({ children, className, identifier }) {
   }
 
   if (!chunks.length) {
-    return children;
+    return <>children</>;
   }
 
   return chunks.map((chunk) => (

--- a/src/useChunk.js
+++ b/src/useChunk.js
@@ -1,6 +1,5 @@
 // @ts-check
-import { useContext } from "react";
-import useSWR from "swr";
+import { useContext, useEffect, useState } from "react";
 
 import { api } from "./api";
 import { EditmodeContext } from "./EditmodeContext";
@@ -9,20 +8,26 @@ import { computeContentKey } from "./utils/computeContentKey";
 
 export function useChunk(defaultContent, { identifier }) {
   const { projectId } = useContext(EditmodeContext);
+  const [[error, chunk], setResponse] = useState([undefined, undefined]);
   const contentKey = defaultContent ? computeContentKey(defaultContent) : null;
 
   const url = identifier
     ? `chunks/${identifier}`
     : `chunks/${contentKey}?project_id=${projectId}`;
 
-  const { data: chunk, error } = useSWR(url, (url) =>
-    api.get(url).then((res) => res.data)
-  );
+  useEffect(() => {
+    api
+      .get(url)
+      .then((res) => setResponse([null, res.data]))
+      .catch((error) => setResponse([error, null]));
+  }, [url]);
 
   if (error) {
-    console.log(
-      `Something went wrong trying to retrieve chunk data: ${error}. Have you provided the correct Editmode identifier as a prop to your Chunk component instance?`
-    );
+    if (identifier) {
+      console.warn(
+        `Something went wrong trying to retrieve chunk data: ${error}. Have you provided the correct Editmode identifier (${identifier}) as a prop to your Chunk component instance?`
+      );
+    }
 
     return {
       Component(props) {

--- a/src/useChunk.js
+++ b/src/useChunk.js
@@ -6,7 +6,7 @@ import { EditmodeContext } from "./EditmodeContext";
 import { renderChunk } from "./utils/renderChunk.jsx";
 import { computeContentKey } from "./utils/computeContentKey";
 
-export function useChunk(defaultContent, { identifier }) {
+export function useChunk(defaultContent, { identifier, type }) {
   const { projectId } = useContext(EditmodeContext);
   const [[error, chunk], setResponse] = useState([undefined, undefined]);
   const contentKey = defaultContent ? computeContentKey(defaultContent) : null;
@@ -33,7 +33,7 @@ export function useChunk(defaultContent, { identifier }) {
       Component(props) {
         return renderChunk(
           {
-            chunk_type: "single_line_text",
+            chunk_type: type || "single_line_text",
             content: defaultContent,
             content_key: contentKey,
           },
@@ -53,12 +53,6 @@ export function useChunk(defaultContent, { identifier }) {
     };
   }
 
-  // TODO What about other content types (e.g. collection, image, etc.?)
-  // Possibilities are:
-  // - <Chunk type={Editmode.IMAGE_CHUNK} />
-  // - useChunk(defaultContent, { identifier: "123", type: Editmode.IMAGE_CHUNK })
-  // - <ImageChunk>
-  // - useChunkCollection / useChunkImage / useChunkCollection
   return {
     Component(props) {
       return renderChunk(chunk, props);

--- a/src/utils/renderChunk.jsx
+++ b/src/utils/renderChunk.jsx
@@ -10,6 +10,7 @@ export const renderChunk = (cnk, props) => {
           data-chunk={chunk.identifier}
           data-chunk-editable={true}
           data-chunk-content-key={chunk.content_key}
+          data-chunk-type="single_line_text"
           key={chunk.identifier}
           {...props}
         >
@@ -22,6 +23,8 @@ export const renderChunk = (cnk, props) => {
           src={chunk.content}
           data-chunk={chunk.identifier}
           data-chunk-editable={false}
+          data-chunk-content-key={chunk.content_key}
+          data-chunk-type="image"
           alt=""
           key={chunk.identifier}
           {...props}


### PR DESCRIPTION
This PR enables creating code-first image chunks to resolve #8.

(It also removes `SWR` due to the amount of API calls it makes.  This does mean that we lose some of its benefits, but it'd be better to handle caching & early-timeouts ourselves. I looked into `react-query`, but it seems way more robust than what we need)

### Before

```jsx
<img src={illustration} width={250} alt="" />
```

### After

```jsx
<Chunk src={illustration} width={250} alt="" />
```

This will automatically pull open a "New Chunk" side-panel **with the `contentKey` set** the first time you edit it.

Once created & refreshed, the chunk loads like normal.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.0.2-canary.11.3826eae.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```sh
  npm install editmode-react@3.0.2-canary.11.3826eae.0
  # or 
  yarn add editmode-react@3.0.2-canary.11.3826eae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
